### PR TITLE
Fix broken image links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ In Github star is the only way to save a repository and you cannot organize with
 
 ### Access your bookmarks from your phone
 
-<img width="288" id="fb-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmarks-android.png">
+<img width="288" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmarks-android.png">
 
 ## Download
 
-<a href=https://chrome.google.com/webstore/detail/voblet/jgnennkfpahpjpbmbbodaipgoilccmco><img height="53" width="188" id="webstore-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/chrome_web_store_badge.png"></a>
+<a href=https://chrome.google.com/webstore/detail/voblet/jgnennkfpahpjpbmbbodaipgoilccmco><img height="53" width="188" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/chrome_web_store_badge.png"></a>
 
-<a href="https://play.google.com/store/apps/details?id=com.voblet"><img height="73" width="188" id="play-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/google-play-badge.png"></a>
+<a href="https://play.google.com/store/apps/details?id=com.voblet"><img height="73" width="188" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/google-play-badge.png"></a>
 
 >Star this repository so that it reaches more people who follow github trending list, it might be useful for them.
 
@@ -50,6 +50,6 @@ Mail contact@voblet.com for more info.
 
 For more updates follow us on the below social platforms
 
-<a href=https://www.facebook.com/voblet><img height="42" width="42" id="fb-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/fb-logo.png"></a>
+<a href=https://www.facebook.com/voblet><img height="42" width="42" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/fb-logo.png"></a>
 
-<a href=https://www.twitter.com/vobletApp><img height="42" width="42" id="fb-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/twitter-logo.png"></a>
+<a href=https://www.twitter.com/vobletApp><img height="42" width="42" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/twitter-logo.png"></a>

--- a/README.md
+++ b/README.md
@@ -16,30 +16,23 @@ Click [here](https://chrome.google.com/webstore/detail/voblet/jgnennkfpahpjpbmbb
 
 In Github star is the only way to save a repository and you cannot organize with custom folders or tags. With voblet you can organize repositories with custom tags. For example, When you find an interesting repository which you want to use for your next side project you can bookmark with 'Side Project' as a tag. You can view your Bookmarks on github just like stars.
 
-
 ## Features :
 
 ### Bookmark your favorite repositories
 
 ![Bookmark your favorite repositories](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmark-repo-zoom.gif "Bookmark Repository")
---
-
 
 ### Bookmark from trending list
 
 ![Bookmark from trending list](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmark-trending-list-zoom.gif "Bookmark From trending list")
---
 
 ### Everything you save is accessible from github
 
 ![Everything you save is accessible from github](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/view-bookmarks-zoom.gif "View Bookmarks")
---
-
 
 ### Access your bookmarks from your phone
 
 <img width="288" id="fb-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmarks-android.png">
---
 
 ## Download
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ In Github star is the only way to save a repository and you cannot organize with
 
 ### Bookmark your favorite repositories
 
-![alt text](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmark-repo-zoom.gif "Bookmark Repository")
+![Bookmark your favorite repositories](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmark-repo-zoom.gif "Bookmark Repository")
 --
 
 
 ### Bookmark from trending list
 
-![alt text](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmark-trending-list-zoom.gif "Bookmark From trending list")
+![Bookmark from trending list](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmark-trending-list-zoom.gif "Bookmark From trending list")
 --
 
 ### Everything you save is accessible from github
 
-![alt text](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/view-bookmarks-zoom.gif "View Bookmarks")
+![Everything you save is accessible from github](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/view-bookmarks-zoom.gif "View Bookmarks")
 --
 
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ Mail contact@voblet.com for more info.
 
 For more updates follow us on the below social platforms
 
-<a href=https://www.facebook.com/voblet><img height="42" width="42" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/fb-logo.png"></a>
-
-<a href=https://www.twitter.com/vobletApp><img height="42" width="42" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/twitter-logo.png"></a>
+<a href=https://www.facebook.com/voblet><img style="margin: 0 10;" height="42" width="42" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/fb-logo.png"></a>
+&nbsp;
+<a href=https://www.twitter.com/vobletApp><img style="margin: 0 10;" height="42" width="42" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/twitter-logo.png"></a>

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ A chrome extension which enables bookmarking feature for github. Bookmark your f
 
 See this 30 sec video for a quick demo
 
-<a href="http://www.youtube.com/watch?v=ykWAo9r79og
-" target="_blank"><img src="https://github.com/sanathp/github-bookmarking-temp/raw/master/images/github_bookmark_video_screenshot.png"
-alt="Bookmarking for github" width="500" border="10" /></a>
+<a href="http://www.youtube.com/watch?v=ykWAo9r79og" target="_blank"><img src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/github_bookmark_video_screenshot.png" alt="Bookmarking for github" width="500" border="10"></a>
 
 Click [here](https://chrome.google.com/webstore/detail/voblet/jgnennkfpahpjpbmbbodaipgoilccmco) to download the chrome extension.
 
@@ -23,31 +21,31 @@ In Github star is the only way to save a repository and you cannot organize with
 
 ### Bookmark your favorite repositories
 
-![alt text](https://github.com/sanathp/github-bookmarking-temp/raw/master/images/bookmark-repo-zoom.gif "Bookmark Repository")
+![alt text](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmark-repo-zoom.gif "Bookmark Repository")
 --
 
 
 ### Bookmark from trending list
 
-![alt text](https://github.com/sanathp/github-bookmarking-temp/raw/master/images/bookmark-trending-list-zoom.gif "Bookmark From trending list")
+![alt text](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmark-trending-list-zoom.gif "Bookmark From trending list")
 --
 
 ### Everything you save is accessible from github
 
-![alt text](https://github.com/sanathp/github-bookmarking-temp/raw/master/images/view-bookmarks-zoom.gif "View Bookmarks")
+![alt text](https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/view-bookmarks-zoom.gif "View Bookmarks")
 --
 
 
 ### Access your bookmarks from your phone
 
-<img width="288" id="fb-logo" src=https://github.com/sanathp/github-bookmarking-temp/raw/master/images/bookmarks-android.png >
+<img width="288" id="fb-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/bookmarks-android.png">
 --
 
 ## Download
 
-<a href=https://chrome.google.com/webstore/detail/voblet/jgnennkfpahpjpbmbbodaipgoilccmco><img height="53" width="188" id="webstore-logo" src=https://github.com/sanathp/github-bookmarking-temp/raw/master/images/chrome_web_store_badge.png ></a>
+<a href=https://chrome.google.com/webstore/detail/voblet/jgnennkfpahpjpbmbbodaipgoilccmco><img height="53" width="188" id="webstore-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/chrome_web_store_badge.png"></a>
 
-<a href="https://play.google.com/store/apps/details?id=com.voblet"><img height="73" width="188" id="play-logo" src=https://github.com/sanathp/github-bookmarking-temp/raw/master/images/google-play-badge.png ></a>
+<a href="https://play.google.com/store/apps/details?id=com.voblet"><img height="73" width="188" id="play-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/google-play-badge.png"></a>
 
 >Star this repository so that it reaches more people who follow github trending list, it might be useful for them.
 
@@ -59,6 +57,6 @@ Mail contact@voblet.com for more info.
 
 For more updates follow us on the below social platforms
 
-<a href=https://www.facebook.com/voblet><img height="42" width="42" id="fb-logo" src=https://github.com/sanathp/github-bookmarking-temp/raw/master/images/fb-logo.png ></a>
+<a href=https://www.facebook.com/voblet><img height="42" width="42" id="fb-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/fb-logo.png"></a>
 
-<a href=https://www.twitter.com/vobletApp><img height="42" width="42" id="fb-logo" src=https://github.com/sanathp/github-bookmarking-temp/raw/master/images/twitter-logo.png ></a>
+<a href=https://www.twitter.com/vobletApp><img height="42" width="42" id="fb-logo" src="https://raw.githubusercontent.com/Voblet/bookmarking-for-github/master/images/twitter-logo.png"></a>


### PR DESCRIPTION
This PR includes some modifications to improve the presentation of README.md.

The main point for this PR is about fixing the invalid image URLs directed by the Markdown image syntax and HTLM image tags.

Here is a list of changes made:

- Fix the Markdown image syntax and HTML image tags were pointing to broken image URLs
- Make Facebook and Twitter PNG images inline for better presentation
- Add descriptive alt text for GIF images
- Strip redundant Markdown syntax
- Strip extra white spaces